### PR TITLE
Refactoring/errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,6 @@ module.exports = {
       '@typescript-eslint/interface-name-prefix': 'off',
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/explicit-module-boundary-types': 'off',
-      "@typescript-eslint/no-explicit-any": "off",
       'prettier/prettier': ['error', {}, { usePrettierrc: true }],
       'arrow-parens': 0,
       'no-debugger': 1,

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,11 +2,13 @@
   "singleQuote": true,
   "trailingComma": "all",
   "tabWidth": 4,
-  "semi": true,
+  "semi": false,
+  "useTabs": false,
   "bracketSpacing": true,
   "bracketSameLine": false,
   "arrowParens": "avoid",
   "endOfLine": "auto",
-  "printWidth": 200,
+  "printWidth": 120,
+  "embeddedLanguageFormatting": "auto",
   "importOrderSeparation": true
 }

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ When strict mode is disabled, the SDK will gracefully handle any errors internal
 - `vennPolicyAddress: string`  
     the address of your  [**Venn Policy**](https://www.npmjs.com/package/@vennbuild/cli#venn-integration)
 
-- `isStrict: boolean`  
+- `strict: boolean`  
     whether or not to enable strict mode *(default: `true`)*
 
 ## 💬 Support & Documentation

--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Your DApp will need to handle this gracefully handle this error:
 > The signed transactions has the same **`to`**, **`from`**, and **`value`**, with an updated **`data`** field that now includes a secure signature that will allow the transaction to go through the onchain Firewall
 
 ```typescript
+import { errors } from '@ironblocks/venn-dapp-sdk'
+
 try {
     const approvedTx = await vennClient.approve({
         from,
@@ -153,6 +155,19 @@ catch (e) {
     // handle errors and unapproved transactions
     //
     // for example, alert the user that the transaction did not pass security checks etc
+
+    if (!(e instanceof Error)) return alert(e)
+
+    switch(error.constructor) {
+        case errors.InvalidInitParamsError:
+            return alert(`Invalid params: ${error.message}`)
+        case errors.ConnectionRefused:
+            return alert(`Network error: ${error.message}`)
+        case errors.TxRejectedError:
+            return alert(`Venn Error: Tx Not Approved: ${error.message}`)
+        default:
+            return alert('Something wrong...')
+    }
 }
 ```
 
@@ -172,8 +187,8 @@ When strict mode is disabled, the SDK will gracefully handle any errors internal
 - `vennPolicyAddress: string`  
     the address of your  [**Venn Policy**](https://www.npmjs.com/package/@vennbuild/cli#venn-integration)
 
-- `strict: boolean`  
-    wether or not to enable strict mode *(default: `true`)*
+- `isStrict: boolean`  
+    whether or not to enable strict mode *(default: `true`)*
 
 ## 💬 Support & Documentation
 

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,3 @@
-export * from '@/errors';
-export * from '@/types/server.types';
-export { VennClient } from '@/venn-client';
+export * from '@/errors'
+export * from '@/types/server.types'
+export { VennClient } from '@/venn-client'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@vennbuild/venn-dapp-sdk",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vennbuild/venn-dapp-sdk",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.3",
@@ -64,9 +64,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -112,12 +112,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -232,13 +232,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/types": "^7.25.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -331,12 +331,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.25.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -376,6 +376,36 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+      "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.24.8"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -492,6 +522,21 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-top-level-await": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
@@ -508,12 +553,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -537,16 +582,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.6",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -564,9 +609,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -605,10 +650,74 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
-      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
       "cpu": [
         "arm64"
       ],
@@ -616,6 +725,310 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -637,9 +1050,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -669,22 +1082,22 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
       "deprecated": "Use @eslint/config-array instead",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
+        "@humanwhocodes/object-schema": "^2.0.3",
         "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
@@ -730,9 +1143,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -1309,10 +1722,36 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.4.tgz",
+      "integrity": "sha512-Fxamp4aEZnfPOcGA8KSNEohV8hX7zVHOemC8jVBoBUHu5zpJK/Eu3uJwt6BMgy9fkvzxDaurgj96F/NiLukF2w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.4.tgz",
+      "integrity": "sha512-VXoK5UMrgECLYaMuGuVTOx5kcuap1Jm8g/M83RnCHBKOqvPPmROFJGQaZhGccnsFtfXQ3XYa4/jMCJvZnbJBdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
-      "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.4.tgz",
+      "integrity": "sha512-xMM9ORBqu81jyMKCDP+SZDhnX2QEVQzTcC6G18KlTQEzWK8r/oNZtKuZaCcHhnsa6fEeOBionoyl5JsAbE/36Q==",
       "cpu": [
         "arm64"
       ],
@@ -1320,6 +1759,175 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.4.tgz",
+      "integrity": "sha512-aJJyYKQwbHuhTUrjWjxEvGnNNBCnmpHDvrb8JFDbeSH3m2XdHcxDd3jthAzvmoI8w/kSjd2y0udT+4okADsZIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.4.tgz",
+      "integrity": "sha512-j63YtCIRAzbO+gC2L9dWXRh5BFetsv0j0va0Wi9epXDgU/XUi5dJKo4USTttVyK7fGw2nPWK0PbAvyliz50SCQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.4.tgz",
+      "integrity": "sha512-dJnWUgwWBX1YBRsuKKMOlXCzh2Wu1mlHzv20TpqEsfdZLb3WoJW2kIEsGwLkroYf24IrPAvOT/ZQ2OYMV6vlrg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.4.tgz",
+      "integrity": "sha512-AdPRoNi3NKVLolCN/Sp4F4N1d98c4SBnHMKoLuiG6RXgoZ4sllseuGioszumnPGmPM2O7qaAX/IJdeDU8f26Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.4.tgz",
+      "integrity": "sha512-Gl0AxBtDg8uoAn5CCqQDMqAx22Wx22pjDOjBdmG0VIWX3qUBHzYmOKh8KXHL4UpogfJ14G4wk16EQogF+v8hmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.4.tgz",
+      "integrity": "sha512-3aVCK9xfWW1oGQpTsYJJPF6bfpWfhbRnhdlyhak2ZiyFLDaayz0EP5j9V1RVLAAxlmWKTDfS9wyRyY3hvhPoOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.4.tgz",
+      "integrity": "sha512-ePYIir6VYnhgv2C5Xe9u+ico4t8sZWXschR6fMgoPUK31yQu7hTEJb7bCqivHECwIClJfKgE7zYsh1qTP3WHUA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.4.tgz",
+      "integrity": "sha512-GqFJ9wLlbB9daxhVlrTe61vJtEY99/xB3C8e4ULVsVfflcpmR6c8UZXjtkMA6FhNONhj2eA5Tk9uAVw5orEs4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.4.tgz",
+      "integrity": "sha512-87v0ol2sH9GE3cLQLNEy0K/R0pz1nvg76o8M5nhMR0+Q+BBGLnb35P0fVz4CQxHYXaAOhE8HhlkaZfsdUOlHwg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.4.tgz",
+      "integrity": "sha512-UV6FZMUgePDZrFjrNGIWzDo/vABebuXBhJEqrHxrGiU6HikPy0Z3LfdtciIttEUQfuDdCn8fqh7wiFJjCNwO+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.4.tgz",
+      "integrity": "sha512-BjI+NVVEGAXjGWYHz/vv0pBqfGoUH0IGZ0cICTn7kB9PyjrATSkX+8WkguNjWoj2qSr1im/+tTGRaY+4/PdcQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.4.tgz",
+      "integrity": "sha512-SiWG/1TuUdPvYmzmYnmd3IEifzR61Tragkbx9D3+R8mzQqDBz8v+BvZNDlkiTtI9T15KYZhP0ehn3Dld4n9J5g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.4.tgz",
+      "integrity": "sha512-j8pPKp53/lq9lMXN57S8cFz0MynJk8OWNuUnXct/9KCpKU7DgU3bYMJhwWmcqC0UU29p8Lr0/7KEVcaM6bf47Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@sinclair/typebox": {
@@ -1466,9 +2074,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.12",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
-      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "version": "29.5.13",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.13.tgz",
+      "integrity": "sha512-wd+MVEZCHt23V0/L642O5APvspWply/rGY5BcW4SUETo2UzPU3Z26qr8jC2qxpimI2jjx9h7+2cj2FwIr01bXg==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -1482,12 +2090,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "22.5.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.5.5.tgz",
+      "integrity": "sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==",
       "dev": true,
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/prettier": {
@@ -1739,9 +2347,9 @@
       }
     },
     "node_modules/acorn-walk": {
-      "version": "8.3.3",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.3.tgz",
-      "integrity": "sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==",
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
       "dev": true,
       "dependencies": {
         "acorn": "^8.11.0"
@@ -1872,9 +2480,9 @@
       }
     },
     "node_modules/async": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true
     },
     "node_modules/asynckit": {
@@ -1883,9 +2491,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.3.tgz",
-      "integrity": "sha512-Ar7ND9pU99eJ9GpoGQKhKf58GpUOgnzuaB7ueNQ5BMi0p+LZ5oaEnfF999fAArcTIBwXTCHAmGcHOZJaWPq9Nw==",
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1970,23 +2578,26 @@
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz",
-      "integrity": "sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.1.0.tgz",
+      "integrity": "sha512-ldYss8SbBlWva1bs28q78Ju5Zq1F+8BrqBZZ0VFhLBvhh6lCpC2o3gDJi/5DRLs9FgYZCnmPYIVFU4lRXCkyUw==",
       "dev": true,
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-bigint": "^7.8.3",
-        "@babel/plugin-syntax-class-properties": "^7.8.3",
-        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
-        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-        "@babel/plugin-syntax-top-level-await": "^7.8.3"
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
@@ -2150,9 +2761,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001650",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001650.tgz",
-      "integrity": "sha512-fgEc7hP/LB7iicdXHUI9VsBsMZmUmlVJeQP2qqQW+3lkqVhbmjEU8zp+h5stWeilX+G7uXuIUIIlWlDw9jdt8g==",
+      "version": "1.0.30001663",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001663.tgz",
+      "integrity": "sha512-o9C3X27GLKbLeTYZ6HBOLU1tsAcBZsLis28wrVzddShCS16RujjHp9GDHKZqrB3meE0YjhawvMFsGb/igqiPzA==",
       "dev": true,
       "funding": [
         {
@@ -2246,9 +2857,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
-      "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.1.tgz",
+      "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true
     },
     "node_modules/cliui": {
@@ -2501,12 +3112,12 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2636,9 +3247,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
-      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==",
+      "version": "1.5.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.27.tgz",
+      "integrity": "sha512-o37j1vZqCoEgBuWWXLHQgTN/KDKe7zwpiY5CPeq2RvUqOyJw9xnrULzZAEVQ5p4h+zjMk7hgtOoPdnLxr7m/jw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -2669,9 +3280,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
-      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -2681,36 +3292,36 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.0",
-        "@esbuild/android-arm": "0.23.0",
-        "@esbuild/android-arm64": "0.23.0",
-        "@esbuild/android-x64": "0.23.0",
-        "@esbuild/darwin-arm64": "0.23.0",
-        "@esbuild/darwin-x64": "0.23.0",
-        "@esbuild/freebsd-arm64": "0.23.0",
-        "@esbuild/freebsd-x64": "0.23.0",
-        "@esbuild/linux-arm": "0.23.0",
-        "@esbuild/linux-arm64": "0.23.0",
-        "@esbuild/linux-ia32": "0.23.0",
-        "@esbuild/linux-loong64": "0.23.0",
-        "@esbuild/linux-mips64el": "0.23.0",
-        "@esbuild/linux-ppc64": "0.23.0",
-        "@esbuild/linux-riscv64": "0.23.0",
-        "@esbuild/linux-s390x": "0.23.0",
-        "@esbuild/linux-x64": "0.23.0",
-        "@esbuild/netbsd-x64": "0.23.0",
-        "@esbuild/openbsd-arm64": "0.23.0",
-        "@esbuild/openbsd-x64": "0.23.0",
-        "@esbuild/sunos-x64": "0.23.0",
-        "@esbuild/win32-arm64": "0.23.0",
-        "@esbuild/win32-ia32": "0.23.0",
-        "@esbuild/win32-x64": "0.23.0"
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "engines": {
         "node": ">=6"
@@ -2729,16 +3340,16 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
         "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "@ungap/structured-clone": "^1.2.0",
@@ -3218,9 +3829,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
-      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
       "funding": [
         {
           "type": "individual",
@@ -3237,9 +3848,9 @@
       }
     },
     "node_modules/foreground-child": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
-      "integrity": "sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
+      "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
       "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -3476,9 +4087,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -3582,9 +4193,9 @@
       "dev": true
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4582,9 +5193,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
@@ -4656,9 +5267,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
     "node_modules/mz": {
@@ -4916,9 +5527,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -5298,9 +5909,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
-      "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.4.tgz",
+      "integrity": "sha512-vD8HJ5raRcWOyymsR6Z3o6+RzfEPCnVLMFJ6vRslO1jt4LO6dUo5Qnpg7y4RkZFM2DMe3WUirkI5c16onjrc6A==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.5"
@@ -5313,22 +5924,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.20.0",
-        "@rollup/rollup-android-arm64": "4.20.0",
-        "@rollup/rollup-darwin-arm64": "4.20.0",
-        "@rollup/rollup-darwin-x64": "4.20.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.20.0",
-        "@rollup/rollup-linux-arm64-musl": "4.20.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.20.0",
-        "@rollup/rollup-linux-x64-gnu": "4.20.0",
-        "@rollup/rollup-linux-x64-musl": "4.20.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.20.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.20.0",
-        "@rollup/rollup-win32-x64-msvc": "4.20.0",
+        "@rollup/rollup-android-arm-eabi": "4.22.4",
+        "@rollup/rollup-android-arm64": "4.22.4",
+        "@rollup/rollup-darwin-arm64": "4.22.4",
+        "@rollup/rollup-darwin-x64": "4.22.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.22.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.22.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.22.4",
+        "@rollup/rollup-linux-arm64-musl": "4.22.4",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.22.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-gnu": "4.22.4",
+        "@rollup/rollup-linux-x64-musl": "4.22.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.22.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.22.4",
+        "@rollup/rollup-win32-x64-msvc": "4.22.4",
         "fsevents": "~2.3.2"
       }
     },
@@ -5740,6 +6351,45 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.6.tgz",
+      "integrity": "sha512-NbBoFBpqfcgd1tCiO8Lkfdk+xrA7mlLR9zgvZcZWQQwU63XAfUePyd6wZBaU93Hqw347lHnwFzttAkemHzzz4g==",
+      "dev": true,
+      "dependencies": {
+        "fdir": "^6.3.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
+      "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+      "dev": true,
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -5816,20 +6466,20 @@
       "dev": true
     },
     "node_modules/ts-jest": {
-      "version": "29.2.4",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.4.tgz",
-      "integrity": "sha512-3d6tgDyhCI29HlpwIq87sNuI+3Q6GLTTCeYRHCs7vDz+/3GCMwEtV9jezLyl4ZtnBgx00I7hm8PCP8cTksMGrw==",
+      "version": "29.2.5",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.2.5.tgz",
+      "integrity": "sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==",
       "dev": true,
       "dependencies": {
-        "bs-logger": "0.x",
+        "bs-logger": "^0.2.6",
         "ejs": "^3.1.10",
-        "fast-json-stable-stringify": "2.x",
+        "fast-json-stable-stringify": "^2.1.0",
         "jest-util": "^29.0.0",
         "json5": "^2.2.3",
-        "lodash.memoize": "4.x",
-        "make-error": "1.x",
-        "semver": "^7.5.3",
-        "yargs-parser": "^21.0.1"
+        "lodash.memoize": "^4.1.2",
+        "make-error": "^1.3.6",
+        "semver": "^7.6.3",
+        "yargs-parser": "^21.1.1"
       },
       "bin": {
         "ts-jest": "cli.js"
@@ -5912,9 +6562,9 @@
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tsup": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.2.4.tgz",
-      "integrity": "sha512-akpCPePnBnC/CXgRrcy72ZSntgIEUa1jN0oJbbvpALWKNOz1B7aM+UVDWGRGIO/T/PZugAESWDJUAb5FD48o8Q==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.3.0.tgz",
+      "integrity": "sha512-ALscEeyS03IomcuNdFdc0YWGVIkwH1Ws7nfTbAPuoILvEV2hpGQAY72LIOjglGo4ShWpZfpBqP/jpQVCzqYQag==",
       "dev": true,
       "dependencies": {
         "bundle-require": "^5.0.0",
@@ -5924,7 +6574,6 @@
         "debug": "^4.3.5",
         "esbuild": "^0.23.0",
         "execa": "^5.1.1",
-        "globby": "^11.1.0",
         "joycon": "^3.1.1",
         "picocolors": "^1.0.1",
         "postcss-load-config": "^6.0.1",
@@ -5932,6 +6581,7 @@
         "rollup": "^4.19.0",
         "source-map": "0.8.0-beta.0",
         "sucrase": "^3.35.0",
+        "tinyglobby": "^0.2.1",
         "tree-kill": "^1.2.2"
       },
       "bin": {
@@ -6083,9 +6733,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6105,9 +6755,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
     },
     "node_modules/universalify": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@vennbuild/venn-dapp-sdk",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@vennbuild/venn-dapp-sdk",
-      "version": "0.8.4",
+      "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.7.3",
         "ethers": "^6.13.2"
       },
       "devDependencies": {
-        "@typechain/ethers-v6": "^0.5.1",
         "@types/jest": "^29.5.12",
         "@types/node": "^22.1.0",
         "@typescript-eslint/eslint-plugin": "^5.59.8",
@@ -27,7 +26,6 @@
         "ts-jest": "^29.2.4",
         "ts-node": "^10.9.2",
         "tsup": "^8.2.4",
-        "typechain": "^8.3.2",
         "typescript": "^5.5.4",
         "yorkie": "^2.0.0"
       }
@@ -1978,21 +1976,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@typechain/ethers-v6": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@typechain/ethers-v6/-/ethers-v6-0.5.1.tgz",
-      "integrity": "sha512-F+GklO8jBWlsaVV+9oHaPh5NJdd6rAKN4tklGfInX1Q7h0xPgVLP39Jl3eCulPB5qexI71ZFHwbljx4ZXNfouA==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.15",
-        "ts-essentials": "^7.0.1"
-      },
-      "peerDependencies": {
-        "ethers": "6.x",
-        "typechain": "^8.3.2",
-        "typescript": ">=4.7.0"
-      }
-    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2097,12 +2080,6 @@
       "dependencies": {
         "undici-types": "~6.19.2"
       }
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.8",
@@ -2460,15 +2437,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
-    },
-    "node_modules/array-back": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -2921,125 +2889,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/command-line-args": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.1.0",
-        "find-replace": "^3.0.0",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^4.0.2",
-        "chalk": "^2.4.2",
-        "table-layout": "^1.0.2",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/command-line-usage/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/command-line-usage/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -3140,15 +2989,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -3780,18 +3620,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-replace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3886,20 +3714,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-      "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
       }
     },
     "node_modules/fs.realpath": {
@@ -4945,12 +4759,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "dev": true
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5015,15 +4823,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/keyv": {
@@ -5107,18 +4906,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
@@ -5252,18 +5039,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -5808,15 +5583,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reduce-flatten": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -6066,12 +5832,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-format": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-format/-/string-format-2.0.0.tgz",
-      "integrity": "sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==",
-      "dev": true
-    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -6277,39 +6037,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/table-layout": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
-      "dev": true,
-      "dependencies": {
-        "array-back": "^4.0.1",
-        "deep-extend": "~0.6.0",
-        "typical": "^5.2.0",
-        "wordwrapjs": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/table-layout/node_modules/array-back": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/table-layout/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -6433,30 +6160,6 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
-      }
-    },
-    "node_modules/ts-command-line-args": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/ts-command-line-args/-/ts-command-line-args-2.5.1.tgz",
-      "integrity": "sha512-H69ZwTw3rFHb5WYpQya40YAX2/w7Ut75uUECbgBIsLmM+BNuYnxsltfyyLMxy6sEeKxgijLTnQtLd0nKd6+IYw==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "command-line-args": "^5.1.1",
-        "command-line-usage": "^6.1.0",
-        "string-format": "^2.0.0"
-      },
-      "bin": {
-        "write-markdown": "dist/write-markdown.js"
-      }
-    },
-    "node_modules/ts-essentials": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz",
-      "integrity": "sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==",
-      "dev": true,
-      "peerDependencies": {
-        "typescript": ">=3.7.0"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -6687,51 +6390,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typechain": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/typechain/-/typechain-8.3.2.tgz",
-      "integrity": "sha512-x/sQYr5w9K7yv3es7jo4KTX05CLxOf7TRWwoHlrjRh8H82G64g+k7VuWPJlgMo6qrjfCulOdfBjiaDtmhFYD/Q==",
-      "dev": true,
-      "dependencies": {
-        "@types/prettier": "^2.1.1",
-        "debug": "^4.3.1",
-        "fs-extra": "^7.0.0",
-        "glob": "7.1.7",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.15",
-        "mkdirp": "^1.0.4",
-        "prettier": "^2.3.1",
-        "ts-command-line-args": "^2.2.0",
-        "ts-essentials": "^7.0.1"
-      },
-      "bin": {
-        "typechain": "dist/cli/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.3.0"
-      }
-    },
-    "node_modules/typechain/node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
@@ -6745,29 +6403,11 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typical": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true
-    },
-    "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.0",
@@ -6876,28 +6516,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/wordwrapjs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
-      "dev": true,
-      "dependencies": {
-        "reduce-flatten": "^2.0.0",
-        "typical": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/wordwrapjs/node_modules/typical": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.5",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.7.3",
+        "axios": "^1.7.7",
         "ethers": "^6.13.2"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "yorkie": "^2.0.0"
   },
   "dependencies": {
-    "axios": "^1.7.3",
+    "axios": "^1.7.7",
     "ethers": "^6.13.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vennbuild/venn-dapp-sdk",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "SDK for interactions with Venn Network",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,9 @@
     "lint:fix": "eslint . --ext .ts --fix",
     "test": "jest --silent=false",
     "publish:npm": "npm pack && npm publish && rm -rf *.tgz",
-    "publish:local": "npm link",
-    "generate-abi-types": "typechain --target=ethers-v6 'src/abi/**/*.json' --out-dir src/types/contracts"
+    "publish:local": "npm link"
   },
   "devDependencies": {
-    "@typechain/ethers-v6": "^0.5.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^22.1.0",
     "@typescript-eslint/eslint-plugin": "^5.59.8",
@@ -51,7 +49,6 @@
     "ts-jest": "^29.2.4",
     "ts-node": "^10.9.2",
     "tsup": "^8.2.4",
-    "typechain": "^8.3.2",
     "typescript": "^5.5.4",
     "yorkie": "^2.0.0"
   },

--- a/src/errors/api.errors.ts
+++ b/src/errors/api.errors.ts
@@ -1,31 +1,31 @@
-export { CanceledError } from 'axios';
+export { CanceledError } from 'axios'
 
 export class ConnectionRefusedError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class NetworkError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class TimeoutError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class AbortedError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class BadRequestError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,7 +1,9 @@
-import * as apiErrors from './api.errors';
-import * as serverErrors from './server.errors';
+import * as apiErrors from './api.errors'
+import * as serverErrors from './server.errors'
+import * as vennClientErrors from './venn-client.errors'
 
 export const errors = {
     ...serverErrors,
     ...apiErrors,
-};
+    ...vennClientErrors,
+}

--- a/src/errors/server.errors.ts
+++ b/src/errors/server.errors.ts
@@ -1,23 +1,23 @@
 export class TxRejectedError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class NoPolicyCallInTraceError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class NoMonitoredAssetsError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }
 
 export class InternalError extends Error {
     constructor(message?: string) {
-        super(message);
+        super(message)
     }
 }

--- a/src/errors/venn-client.errors.ts
+++ b/src/errors/venn-client.errors.ts
@@ -1,0 +1,5 @@
+export class InvalidInitParamsError extends Error {
+    constructor(message?: string) {
+        super(message)
+    }
+}

--- a/src/helpers/error.helpers.ts
+++ b/src/helpers/error.helpers.ts
@@ -1,70 +1,70 @@
-import { AxiosError, isAxiosError } from 'axios';
+import { AxiosError, isAxiosError } from 'axios'
 
-import { errors } from '@/errors';
-import { API_ERROR_CODE, TxStatus } from '@/types';
+import { errors } from '@/errors'
+import { API_ERROR_CODE, TxStatus } from '@/types'
 
 type ResponseData = {
-    message: string;
-    status: TxStatus;
-    data: any;
-};
+    message: string
+    status: TxStatus
+    data: unknown
+}
 
 const isLegacyServerLikeError = (error: AxiosError) =>
     typeof error === 'object' &&
     error !== null &&
     typeof error.response?.data === 'object' &&
     error.response?.data !== null &&
-    ['message', 'status'].every(prop => Object.prototype.hasOwnProperty.call(error.response?.data as object, prop));
+    ['message', 'status'].every(prop => Reflect.has(error.response?.data as object, prop))
 
 export const parseServerError = (error: unknown) => {
-    if (!isLegacyServerLikeError(error as AxiosError)) return error;
+    if (!isAxiosError(error)) return error
+    if (!isLegacyServerLikeError(error)) return error
 
-    const responseData = (error as AxiosError).response?.data as ResponseData;
-    const message = responseData.message;
-    const status = responseData.status;
+    const responseData = (error as AxiosError).response?.data as ResponseData
+    const message = responseData.message
+    const status = responseData.status
 
-    const parseServerError = (message: string) => {
-        const _message = message.toLowerCase();
+    // not sure if this is still relevant
+    const _parseServerError = (message: string) => {
+        const _message = message.toLowerCase()
 
         switch (true) {
             case _message.includes('policy'):
-                return new errors.NoPolicyCallInTraceError(message);
+                return new errors.NoPolicyCallInTraceError(message)
             case _message.includes('invalid request'):
-                return new errors.BadRequestError(message);
+                return new errors.BadRequestError(message)
             case _message.includes('monitored assets'):
-                return new errors.NoMonitoredAssetsError(message);
+                return new errors.NoMonitoredAssetsError(message)
             default:
-                return new errors.InternalError(message);
+                return new errors.InternalError(message)
         }
-    };
+    }
 
     switch (status) {
         case 'Rejected':
-            return new errors.TxRejectedError(message);
+            return new errors.TxRejectedError(message)
         case 'Error':
-            return parseServerError(message);
+            return _parseServerError(message)
         default:
-            return new errors.InternalError(message);
+            return new errors.InternalError(message)
     }
-};
-
-export const parseErrorMessage = (error: unknown) => (error instanceof Error ? error.message : String(error));
+}
 
 export const parseApiError = (error: unknown) => {
-    if (!isAxiosError(error)) return null;
+    if (!isAxiosError(error)) return null
 
     switch (error.code) {
         case API_ERROR_CODE.connectionRefused:
-            return new errors.ConnectionRefusedError(error.message);
+            return new errors.ConnectionRefusedError(error.message)
         case API_ERROR_CODE.network:
-            return new errors.NetworkError(error.message);
+            return new errors.NetworkError(error.message)
         case API_ERROR_CODE.timeout:
-            return new errors.TimeoutError(error.message);
+            return new errors.TimeoutError(error.message)
         case API_ERROR_CODE.aborted:
-            return new errors.AbortedError(error.message);
+            return new errors.AbortedError(error.message)
         case API_ERROR_CODE.badRequest:
-            return new errors.BadRequestError(error.message);
+            return new errors.BadRequestError(error.message)
         default:
-            return null;
+            return null
     }
-};
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,2 @@
-export * from './error.helpers';
+export * from './error.helpers'
+export * from './validation.helpers'

--- a/src/helpers/validation.helpers.ts
+++ b/src/helpers/validation.helpers.ts
@@ -1,0 +1,12 @@
+import { isAddress } from 'ethers'
+
+export const isValidUrl = (url: string) => {
+    try {
+        new URL(url)
+        return true
+    } catch {
+        return false
+    }
+}
+
+export const isValidEthereumAddress = (address: unknown) => isAddress(address)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
-export * from './api.types';
-export * from './server.types';
-export { type VennClientCreateOpts } from '@/venn-client';
+export * from './api.types'
+export * from './server.types'
+export { type VennClientCreateOpts } from '@/venn-client'

--- a/src/types/server.types.ts
+++ b/src/types/server.types.ts
@@ -1,14 +1,14 @@
-import { ethers } from 'ethers';
+import { ethers } from 'ethers'
 
-export type TxStatus = 'Approved' | 'Rejected' | 'Error';
+export type TxStatus = 'Approved' | 'Rejected' | 'Error'
 
 export type SignedTxResponse = {
-    requestId: string;
-    status: TxStatus;
-    data: ethers.TransactionRequest;
-    message?: string;
-};
+    requestId: string
+    status: TxStatus
+    data: ethers.TransactionRequest
+    message?: string
+}
 
 export type SignTxServerRequest = ethers.TransactionRequest & {
-    approvingPolicyAddress: string;
-};
+    approvingPolicyAddress: string
+}

--- a/src/venn-client/index.ts
+++ b/src/venn-client/index.ts
@@ -8,7 +8,7 @@ import { type SignedTxResponse, type SignTxServerRequest } from '@/types'
 export type VennClientCreateOpts = {
     vennURL: string
     vennPolicyAddress: string
-    isStrict?: boolean
+    strict?: boolean
 }
 
 export class VennClient {
@@ -18,13 +18,13 @@ export class VennClient {
 
     protected apiInstance: AxiosInstance
 
-    protected isStrict: boolean
+    protected strict: boolean
 
     /**
      * Creates a new VennClient instance.
      * @param {string} opts.url - The URL of the Venn Node.
      * @param {string} opts.vennPolicyAddress - The address of the policy.
-     * @param {boolean} [opts.isStrict=true] - Optional. Whether to throw an error if the response Venn Network is not 'Approved' or if an error occurs. If set to false, will return the request data on failure. Defaults to true.
+     * @param {boolean} [opts.strict=true] - Optional. Whether to throw an error if the response Venn Network is not 'Approved' or if an error occurs. If set to false, will return the request data on failure. Defaults to true.
      * @throws {Error} If any required property is missing.
      */
     constructor(opts: VennClientCreateOpts) {
@@ -32,7 +32,7 @@ export class VennClient {
 
         this.url = opts.vennURL
         this.vennPolicyAddress = opts.vennPolicyAddress
-        this.isStrict = opts.isStrict ?? true
+        this.strict = opts.strict ?? true
 
         this.apiInstance = axios.create({ baseURL: this.url })
     }
@@ -70,7 +70,7 @@ export class VennClient {
      * @param {string} txData.value - The amount of Ether to send with the transaction (required)
      * @param {string} txData.data - The data payload of the transaction (required)
      * @returns {ethers.TransactionRequest} The approved transaction request. Includes a from, to, value and data
-     * @throws {Error} If isStrict is true, and the transaction request is not approved or an error occurs. If isStrict set to false, will return the transaction request on failure.
+     * @throws {Error} If strict is true, and the transaction request is not approved or an error occurs. If strict set to false, will return the transaction request on failure.
      */
     public async approve(txData: TransactionRequest): Promise<TransactionRequest> {
         try {
@@ -99,7 +99,7 @@ export class VennClient {
     }
 
     private handleError(error: unknown, txData: TransactionRequest): TransactionRequest {
-        if (this.isStrict) throw error
+        if (this.strict) throw error
 
         // npm unwraps the 'data' property of the object
         // npm do what?? (c) Mark

--- a/src/venn-client/index.ts
+++ b/src/venn-client/index.ts
@@ -44,7 +44,7 @@ export class VennClient {
                 approvingPolicyAddress: this.vennPolicyAddress,
             }
 
-            const { data: signedData } = await this.apiInstance.post<SignedTxResponse>('/sign', requestData)
+            const { data: signedData } = await this.apiInstance.post<SignedTxResponse>('', requestData)
 
             // some errors come with 200 status ^_^
             if (signedData.status !== 'Approved') {

--- a/tests/sanity.test.ts
+++ b/tests/sanity.test.ts
@@ -1,6 +1,6 @@
 describe('Sanity tests', () => {
     test('boolean test', () => {
-        expect(true).toBeTruthy();
-        expect(false).toBeFalsy();
-    });
-});
+        expect(true).toBeTruthy()
+        expect(false).toBeFalsy()
+    })
+})

--- a/tests/venn-client-mocked-api.test.ts
+++ b/tests/venn-client-mocked-api.test.ts
@@ -55,7 +55,7 @@ const MOCKED_SIGNER_RESPONSE = {
 
 let vennClient: VennClientExposed
 
-describe('Venn Client Tests', () => {
+describe('Venn Client Mocked Tests', () => {
     describe('Init tests', () => {
         test('default init', () => {
             const client = new VennClientExposed({

--- a/tests/venn-client-testnet.test.ts
+++ b/tests/venn-client-testnet.test.ts
@@ -1,0 +1,38 @@
+import { errors } from '@/errors'
+import { VennClient } from '@/venn-client'
+
+const VENN_NODE_URL = 'http://signer.testnet.venn.build/api/17000/sign'
+const POLICY_ADDRESS = '0xf4E5AB115d0775caf24eF25979991516f2283C20'
+const VENN_NODE_REJECT_URL = 'http://signer.testnet.venn.build/api/17000/mock/reject'
+
+const TX_DATA = {
+    from: '0x6738fA889fF31F82d9Fe8862ec025dbE318f3Fde',
+    to: '0xF06Ab383528F51dA67E2b2407327731770156ED6',
+    value: '0',
+    data: '0x2ebd2116000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000009a5cd1145791b29ac4e68df3bf8e30d2167daa76000000000000000000000000a150a825d425b36329d8294eef8bd0fe68f8f6e000000000000000000000000067c5870b4a41d4ebef24d2456547a03f1f3e094b0000000000000000000000000c6c80d2061afa35e160f3799411d83bdeea0a5a000000000000000000000000000000000000000000000000000004a15724a9fd',
+} as const
+
+describe('Venn Client Testnet', () => {
+    test('Valid signature', async () => {
+        const vennClient = new VennClient({
+            vennURL: VENN_NODE_URL,
+            vennPolicyAddress: POLICY_ADDRESS,
+        })
+
+        const resp = await vennClient.approve(TX_DATA)
+
+        expect(resp.data).not.toBe(TX_DATA.data) // data embedded with signature
+        expect(resp.from).toBe(TX_DATA.from)
+        expect(resp.to).toBe(TX_DATA.to)
+        expect(resp.value).toBe(TX_DATA.value)
+    })
+
+    test('Rejection', () => {
+        const vennClient = new VennClient({
+            vennURL: VENN_NODE_REJECT_URL,
+            vennPolicyAddress: POLICY_ADDRESS,
+        })
+
+        expect(() => vennClient.approve(TX_DATA)).rejects.toThrow(errors.TxRejectedError)
+    })
+})

--- a/tests/venn-client.test.ts
+++ b/tests/venn-client.test.ts
@@ -1,59 +1,59 @@
-import { AxiosInstance } from 'axios';
-import { ethers, ZeroAddress } from 'ethers';
+import { AxiosInstance } from 'axios'
+import { ethers, ZeroAddress } from 'ethers'
 
-import { VennClient, VennClientCreateOpts } from '@/venn-client';
+import { errors } from '@/errors'
+import { VennClient, VennClientCreateOpts } from '@/venn-client'
 
-jest.mock('axios');
+jest.mock('axios')
 
 /* FOR TESTING NON-PUBLIC METHODS AND FIELDS */
 class VennClientExposed extends VennClient {
     constructor(data: VennClientCreateOpts) {
-        super(data);
+        super(data)
     }
 
     public _getSignature(txData: ethers.TransactionRequest) {
-        return this.getSignature(txData);
+        return this.getSignature(txData)
     }
 
     set _apiInstance(apiInstance: AxiosInstance) {
-        this.apiInstance = apiInstance;
+        this.apiInstance = apiInstance
     }
 
     get _url() {
-        return this.url;
+        return this.url
     }
 
     get _vennPolicyAddress() {
-        return this.vennPolicyAddress;
+        return this.vennPolicyAddress
     }
 
-    get _strict() {
-        return this.strict;
+    get _isStrict() {
+        return this.isStrict
     }
 
-    set _strict(strict: boolean) {
-        this.strict = strict;
+    set _isStrict(isStrict: boolean) {
+        this.isStrict = isStrict
     }
 }
 
-const VENN_NODE_URL = 'http://www.this-is-a-fake-url.com';
-const POLICY_ADDRESS = ZeroAddress;
+const VENN_NODE_URL = 'http://this-is-a-fake-url.com'
+const POLICY_ADDRESS = ZeroAddress
 
 const MOCKED_TX = {
-    requestId: 'unique-id',
     from: '0x6738fA889fF31F82d9Fe8862ec025dbE318f3Fde',
     to: '0xF06Ab383528F51dA67E2b2407327731770156ED6',
     value: '0',
     data: '0x2ebd2116000000000000000000000000c02aaa39b223fe8d0a0e5c4f27ead9083c756cc20000000000000000000000009a5cd1145791b29ac4e68df3bf8e30d2167daa76000000000000000000000000a150a825d425b36329d8294eef8bd0fe68f8f6e000000000000000000000000067c5870b4a41d4ebef24d2456547a03f1f3e094b0000000000000000000000000c6c80d2061afa35e160f3799411d83bdeea0a5a000000000000000000000000000000000000000000000000000004a15724a9fd',
-};
+} as const
 
 const MOCKED_SIGNER_RESPONSE = {
     requestId: 'unique-id',
     status: 'Approved',
     data: MOCKED_TX,
-};
+} as const
 
-let vennClient: VennClientExposed;
+let vennClient: VennClientExposed
 
 describe('Venn Client Tests', () => {
     describe('Init tests', () => {
@@ -61,93 +61,109 @@ describe('Venn Client Tests', () => {
             const client = new VennClientExposed({
                 vennURL: VENN_NODE_URL,
                 vennPolicyAddress: POLICY_ADDRESS,
-            });
+            })
 
-            expect(client._url).toBe(VENN_NODE_URL);
-            expect(typeof client.approve).toBe('function');
-        });
+            expect(client._url).toBe(VENN_NODE_URL)
+            expect(client._vennPolicyAddress).toBe(POLICY_ADDRESS)
+            expect(typeof client.approve).toBe('function')
+        })
 
         describe('Validation tests', () => {
             test('invalid url', () => {
                 expect(() => {
-                    const client = new VennClientExposed({
+                    new VennClient({
                         vennURL: 'invalid-url',
                         vennPolicyAddress: POLICY_ADDRESS,
-                    });
-                    client._url;
-                }).toThrow(/Invalid URL provided./);
-            });
+                    })
+                }).toThrow(errors.InvalidInitParamsError)
+            })
             test('invalid policy address', () => {
                 expect(() => {
-                    const client = new VennClientExposed({
+                    new VennClient({
                         vennURL: VENN_NODE_URL,
                         vennPolicyAddress: 'invalid-address',
-                    });
-                    client._vennPolicyAddress;
-                }).toThrow(/Invalid Ethereum address provided for vennPolicyAddress./);
-            });
-        });
-    });
+                    })
+                }).toThrow(errors.InvalidInitParamsError)
+            })
+        })
+    })
 
     describe('Functionality tests', () => {
         beforeAll(() => {
             vennClient = new VennClientExposed({
                 vennURL: VENN_NODE_URL,
                 vennPolicyAddress: POLICY_ADDRESS,
-            });
-        });
+            })
+        })
 
         describe('Private methods', () => {
             describe('_getSignature', () => {
                 beforeEach(() => {
                     vennClient._apiInstance = {
                         post: jest.fn().mockResolvedValue({ data: MOCKED_SIGNER_RESPONSE }),
-                    } as unknown as AxiosInstance;
-                });
-
+                    } as unknown as AxiosInstance
+                })
                 afterEach(() => {
-                    jest.resetAllMocks();
-                });
+                    jest.resetAllMocks()
+                })
+
                 test('should return a signature', async () => {
-                    const signature = await vennClient._getSignature(MOCKED_TX);
-                    expect(signature).toBeDefined();
-                });
-            });
-        });
+                    const signature = await vennClient._getSignature(MOCKED_TX)
+
+                    expect(signature).toBeDefined()
+                    expect(signature.data).toEqual(MOCKED_SIGNER_RESPONSE.data)
+                })
+            })
+        })
 
         describe('Public methods', () => {
+            afterEach(() => {
+                jest.resetAllMocks()
+            })
+
             describe('approve', () => {
                 test('no connection fail', async () => {
-                    expect(vennClient.approve(MOCKED_TX)).rejects.toThrow();
-                });
+                    vennClient._apiInstance = {
+                        post: jest.fn().mockRejectedValue(new errors.ConnectionRefusedError()),
+                    } as unknown as AxiosInstance
+
+                    expect(() => vennClient.approve(MOCKED_TX)).rejects.toThrow(errors.ConnectionRefusedError)
+                })
+
                 test('should return a return signed data', async () => {
                     vennClient._apiInstance = {
                         post: jest.fn().mockResolvedValue({ data: MOCKED_SIGNER_RESPONSE }),
-                    } as unknown as AxiosInstance;
+                    } as unknown as AxiosInstance
 
-                    const signedData = await vennClient.approve(MOCKED_TX);
+                    const signedData = await vennClient.approve(MOCKED_TX)
                     // return value is the same as the input since no signing is done
-                    expect(signedData).toBe(MOCKED_TX);
+                    expect(signedData).toBe(MOCKED_TX)
 
-                    jest.resetAllMocks();
-                });
+                    jest.resetAllMocks()
+                })
 
                 test('strict mode should throw error', async () => {
-                    vennClient._strict = true;
-
                     vennClient._apiInstance = {
-                        post: jest.fn().mockRejectedValue(new Error('API request failed')),
-                    } as unknown as AxiosInstance;
-                    expect(vennClient.approve(MOCKED_TX)).rejects.toThrow();
-                });
+                        post: jest.fn().mockRejectedValue(new errors.InternalError('API request failed')),
+                    } as unknown as AxiosInstance
 
-                test('strict mode should return original data', async () => {
-                    vennClient._apiInstance = {
-                        post: jest.fn().mockResolvedValue({ data: MOCKED_SIGNER_RESPONSE }),
-                    } as unknown as AxiosInstance;
-                    expect(vennClient.approve(MOCKED_TX)).resolves.toBe(MOCKED_TX);
-                });
-            });
-        });
-    });
-});
+                    expect(vennClient.approve(MOCKED_TX)).rejects.toThrow(errors.InternalError)
+                })
+
+                test('not strict mode should return original data on error', async () => {
+                    const client = new VennClientExposed({
+                        vennURL: VENN_NODE_URL,
+                        vennPolicyAddress: POLICY_ADDRESS,
+                        isStrict: false,
+                    })
+
+                    client._apiInstance = {
+                        post: jest.fn().mockRejectedValue(new errors.InternalError('API request failed')),
+                    } as unknown as AxiosInstance
+
+                    expect(client.approve(MOCKED_TX)).resolves.toEqual(MOCKED_TX)
+                })
+            })
+        })
+    })
+})

--- a/tests/venn-client.test.ts
+++ b/tests/venn-client.test.ts
@@ -28,12 +28,12 @@ class VennClientExposed extends VennClient {
         return this.vennPolicyAddress
     }
 
-    get _isStrict() {
-        return this.isStrict
+    get _strict() {
+        return this.strict
     }
 
-    set _isStrict(isStrict: boolean) {
-        this.isStrict = isStrict
+    set _strict(strict: boolean) {
+        this.strict = strict
     }
 }
 
@@ -154,7 +154,7 @@ describe('Venn Client Tests', () => {
                     const client = new VennClientExposed({
                         vennURL: VENN_NODE_URL,
                         vennPolicyAddress: POLICY_ADDRESS,
-                        isStrict: false,
+                        strict: false,
                     })
 
                     client._apiInstance = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "importHelpers": true,
+    "noImplicitAny": true,
     "baseUrl": "./",
     "outDir": "dist",
     "paths": {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsup'
 
 export default defineConfig({
     entry: ['./index.ts'],
@@ -7,4 +7,4 @@ export default defineConfig({
     splitting: false,
     sourcemap: true,
     clean: true,
-});
+})


### PR DESCRIPTION
- added using custom errors classes approach with single entry point in `@/errors`
- moved validations out of main class
- removed disabling of eslint rule `@typescript-eslint/no-explicit-any`; using of type `any` can be replaced with `unknown` in most scenarios
- reduced `printWidth` in `prettier` config; hard to read code when it can't even fit your screen horizontally
- removed `typechain` from deps since it is no longer used
- adjusted tests to work with custom errors
- made return types of the methods more consistent