### PR TITLE
Fix/unhandled provider error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vennbuild/venn-dapp-sdk",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "SDK for interactions with Venn Network",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/errors/venn-client.errors.ts
+++ b/src/errors/venn-client.errors.ts
@@ -3,3 +3,9 @@ export class InvalidInitParamsError extends Error {
         super(message)
     }
 }
+
+export class MissingChainIdError extends Error {
+    constructor(message?: string) {
+        super(message)
+    }
+}

--- a/src/venn-client/index.ts
+++ b/src/venn-client/index.ts
@@ -1,10 +1,28 @@
-import { createProvider, MetamaskProvider, Provider, ProviderDetector } from '@distributedlab/w3p'
+import {
+    CoinbaseProvider,
+    createProvider,
+    errors as web3Errors,
+    MetamaskProvider,
+    Provider,
+    ProviderDetector,
+    ProviderProxyConstructor,
+    PROVIDERS,
+} from '@distributedlab/w3p'
 import axios, { AxiosInstance } from 'axios'
 import { TransactionRequest } from 'ethers'
 
 import { errors } from '@/errors'
 import { isValidEthereumAddress, isValidUrl, parseApiError, parseServerError } from '@/helpers'
 import { type SignedTxResponse, type SignTxServerRequest } from '@/types'
+
+const supportedProviders: {
+    [key in VennSupportedProviders]: ProviderProxyConstructor
+} = {
+    [PROVIDERS.Metamask]: MetamaskProvider,
+    [PROVIDERS.Coinbase]: CoinbaseProvider,
+}
+
+export type VennSupportedProviders = PROVIDERS.Metamask | PROVIDERS.Coinbase
 
 export type VennClientCreateOpts = {
     vennURL: string
@@ -45,11 +63,25 @@ export class VennClient {
     protected async initProvider() {
         if (typeof window === 'undefined') return
 
-        const providerDetector = new ProviderDetector()
+        try {
+            const providerDetector = new ProviderDetector()
 
-        await providerDetector.init()
+            await providerDetector.init()
 
-        this.web3Provider = await createProvider(MetamaskProvider, { providerDetector: providerDetector })
+            const availableProviders = Object.keys(providerDetector.providers) as VennSupportedProviders[]
+
+            if (!availableProviders.length) throw new web3Errors.ProviderInjectedInstanceNotFoundError()
+
+            const providerProxyConstructor = supportedProviders[availableProviders[0]]
+
+            this.web3Provider = await createProvider(providerProxyConstructor, { providerDetector: providerDetector })
+        } catch (error) {
+            console.warn(
+                `Web3Provider in VennClient was not initialized: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            )
+        }
     }
 
     protected async getSignature(txData: TransactionRequest): Promise<SignedTxResponse> {
@@ -59,6 +91,11 @@ export class VennClient {
                 approvingPolicyAddress: this.vennPolicyAddress,
                 chainId: txData?.chainId ?? this.web3Provider?.chainId,
             }
+
+            if (!requestData.chainId)
+                throw new errors.MissingChainIdError(
+                    'Chain id was not provided in request and was not available via injected provider',
+                )
 
             const { data: signedData } = await this.apiInstance.post<SignedTxResponse>('', requestData)
 

--- a/tests/venn-client-mocked-api.test.ts
+++ b/tests/venn-client-mocked-api.test.ts
@@ -41,6 +41,7 @@ const VENN_NODE_URL = 'http://this-is-a-fake-url.com'
 const POLICY_ADDRESS = ZeroAddress
 
 const MOCKED_TX = {
+    chainId: 1,
     from: '0x6738fA889fF31F82d9Fe8862ec025dbE318f3Fde',
     to: '0xF06Ab383528F51dA67E2b2407327731770156ED6',
     value: '0',
@@ -112,6 +113,13 @@ describe('Venn Client Mocked Tests', () => {
 
                     expect(signature).toBeDefined()
                     expect(signature.data).toEqual(MOCKED_SIGNER_RESPONSE.data)
+                })
+
+                test('should throw MissingChainId error', async () => {
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    const { chainId, ...TX_WITH_NO_CHAIN } = MOCKED_TX
+
+                    expect(() => vennClient._getSignature(TX_WITH_NO_CHAIN)).rejects.toThrow(errors.MissingChainIdError)
                 })
             })
         })


### PR DESCRIPTION
- `initProvider` used to throw unhandled error in case wallet is not injected in browser
- added `MissingChainId` error
- added support for CoinBase provider